### PR TITLE
Add test for filter when sortStatus is not 3

### DIFF
--- a/src/utils/filterTasksByCategory.test.js
+++ b/src/utils/filterTasksByCategory.test.js
@@ -2,48 +2,57 @@ import expect from 'expect';
 
 import { filterTasksByCategory } from './filterTasksByCategory';
 
+const tasks = [
+    {
+        category: 1,
+        event_et_tm: '2020-06-06T17:45:00.000Z',
+        event_st_tm: '2020-06-05T17:11:00.000Z',
+    },
+    {
+        category: 0,
+        event_et_tm: '2020-05-16T17:45:00.000Z',
+        event_st_tm: '2020-05-16T17:11:00.000Z',
+    },
+    {
+        category: 0,
+        event_et_tm: '2020-05-19T17:45:00.000Z',
+        event_st_tm: '2020-05-19T17:11:00.000Z',
+    },
+    {
+        category: 2,
+        event_et_tm: '2020-06-02T17:45:00.000Z',
+        event_st_tm: '2020-06-02T17:11:00.000Z',
+    },
+    {
+        category: 1,
+        event_et_tm: '2020-05-18T17:45:00.000Z',
+        event_st_tm: '2020-05-18T17:11:00.000Z',
+    },
+    {
+        category: 2,
+        event_et_tm: '2020-05-19T17:45:00.000Z',
+        event_st_tm: '2020-05-19T17:11:00.000Z',
+    },
+    {
+        category: 1,
+        event_et_tm: '2020-06-02T17:45:00.000Z',
+        event_st_tm: '2020-06-02T17:11:00.000Z',
+    },
+];
+
 describe('filterTasksByCategory', () => {
     it('successfully shows all tasks regardless of date', () => {
-        const tasks = [
-            {
-                category: 1,
-                event_et_tm: '2020-06-06T17:45:00.000Z',
-                event_st_tm: '2020-06-05T17:11:00.000Z',
-            },
-            {
-                category: 0,
-                event_et_tm: '2020-05-16T17:45:00.000Z',
-                event_st_tm: '2020-05-16T17:11:00.000Z',
-            },
-            {
-                category: 0,
-                event_et_tm: '2020-05-19T17:45:00.000Z',
-                event_st_tm: '2020-05-19T17:11:00.000Z',
-            },
-            {
-                category: 2,
-                event_et_tm: '2020-06-02T17:45:00.000Z',
-                event_st_tm: '2020-06-02T17:11:00.000Z',
-            },
-            {
-                category: 1,
-                event_et_tm: '2020-05-18T17:45:00.000Z',
-                event_st_tm: '2020-05-18T17:11:00.000Z',
-            },
-            {
-                category: 2,
-                event_et_tm: '2020-05-19T17:45:00.000Z',
-                event_st_tm: '2020-05-19T17:11:00.000Z',
-            },
-            {
-                category: 1,
-                event_et_tm: '2020-06-02T17:45:00.000Z',
-                event_st_tm: '2020-06-02T17:11:00.000Z',
-            },
-        ];
-
         const sortStatus = 3; // sortStatus for getting all categories is 3
         const expectedLength = tasks.length;
+
+        const actual = filterTasksByCategory(tasks, sortStatus);
+
+        expect(actual.length).toBe(expectedLength);
+    });
+
+    it('successfully shows tasks with the same category as the sortStatus', () => {
+        const sortStatus = 2;
+        const expectedLength = 2;
 
         const actual = filterTasksByCategory(tasks, sortStatus);
 


### PR DESCRIPTION
# Description
Added another test to check the other half of the conditional in the filter logic since the file only had 50% test coverage. This test checks to see if the events are properly filtered by category if the sortStatus is not 3 (i.e. the user clicked on a tag other than "All").


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
