### PR TITLE
Fix test coverage command to the create-react-app coverage command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,5 @@ jobs:
           CI: true
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
-          coverageCommand: npm run coverage
+          coverageCommand: npm test -- --coverage --watchAll=false
           coverageLocations: 'client/coverage/lcov.info:lcov'


### PR DESCRIPTION
# Description
Updated the test coverage command in the `ci.yml` for the codeclimate stuff. The old one was with whatever the jest config stuff was, so I changed it to the command that `create-react-app` uses.

Fixes # (issue)
Should fix the failing check for PRs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
