### PR TITLE
Update prettier to ignore yml files so it will stop changing the spac…

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,20 +1,20 @@
 version: '2'
 checks:
-  # Disable checks for similar code.
-  # Because this creates too many false positives.
-  similar-code:
-    enabled: false
-  # Increase the number of lines allowed for a method.
-  # Because this is more reasonable for JavaScript.
-  method-lines:
-    config:
-      threshold: 50
-exclude_patterns:
-  - 'tests/'
-  - 'spec/'
-  - '**/*.spec.js'
-  - '**/*.spec.jsx'
-  - '**/*.spec.ts'
-  - '**/*.spec.tsx'
-  - '**/vendor/'
-  - '**/node_modules/'
+    # Disable checks for similar code.
+    # Because this creates too many false positives.
+    similar-code:
+      enabled: false
+    # Increase the number of lines allowed for a method.
+    # Because this is more reasonable for JavaScript.
+    method-lines:
+      config:
+        threshold: 50
+  exclude_patterns:
+    - 'tests/'
+    - 'spec/'
+    - '**/*.spec.js'
+    - '**/*.spec.jsx'
+    - '**/*.spec.ts'
+    - '**/*.spec.tsx'
+    - '**/vendor/'
+    - '**/node_modules/'

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "*.js": [
       "eslint"
     ],
-    "*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx)": [
+    "*.+(js|jsx|json|css|less|scss|ts|tsx|md|graphql|mdx)": [
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
…ing and breaking it

# Description
Husky/lint-staged were running our prettier rules, which were changing the spacing in the yml files. So I changed our lint-staged script so that it won't run prettier on yml files because changing the spacing breaks it.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
