### PR TITLE
Update default theme colors to blues. Update input and form styles to…

### DIFF
--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -18,11 +18,11 @@ export default {
     heading: 1.125,
   },
   colors: {
-    text: '#000',
+    text: '#002550',
     background: '#fff',
-    primary: '#FFB96F',
-    secondary: '#EF6116',
-    muted: '#FFE2BF',
+    primary: '#82D1FF',
+    secondary: '#002550',
+    muted: '#EDEDED',
     modes: {
       dark: {
         text: '#062647',
@@ -52,15 +52,13 @@ export default {
   },
   buttons: {
     primary: {
-      bg: 'muted',
+      bg: 'primary',
       color: 'text',
       transition: `all 0.15s ease-in-out`,
 
       '&:hover': {
         bg: 'secondary',
         color: 'background',
-        boxShadow:
-          '0 3px 3px 0 rgba(0, 0, 0, 0.16), 0 3px 3px 0 rgba(0, 0, 0, 0.23)',
 
         '&:focus': {
           outline: 'none',
@@ -71,15 +69,16 @@ export default {
   forms: {
     input: {
       border: 'none',
-      bg: 'muted',
+      borderBottom: '1px solid',
+      borderColor: 'muted',
+      borderRadius: '0',
       transition: `all 0.15s ease-in-out`,
 
       '&:focus': {
         border: 'none',
         outline: 'none',
-        bg: 'muted',
-        boxShadow:
-          '0 3px 3px 0 rgba(0, 0, 0, 0.16), 0 3px 3px 0 rgba(0, 0, 0, 0.23)',
+        borderBottom: '1px solid',
+        borderColor: 'text',
       },
     },
   },


### PR DESCRIPTION
… match new design

# Description
Changed the colors for the default/'light' mode. Didn't bother with the dark mode ones for now since that can probably be part of another release canvas. 

The darker blue that we wanted for the text and header is the color for `text` and `secondary`. The lighter blue is the color for `primary`. The `background` is still white and `muted` is that faded gray that's being used for the input boxes' bottom border color from Louie's Figma design.

Also updated the styling for the `primary` button and the `inputs` for forms to reflect the design, as well.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
Only changed the theme file, so no tests were written

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
