### PR TITLE
Link add icon to create task form

### DIFF
--- a/src/components/AddTaskButton.js
+++ b/src/components/AddTaskButton.js
@@ -10,6 +10,7 @@ export default function FloatingActionButtons() {
         display: 'flex',
         justifyContent: 'center',
         // alignItems: 'center', // for some reason having this makes the text move lower and not look vertically centered
+        fontFamily: 'initial', // our font family also seems to lower the text, but if we override it back to the initial font family, it seems to vertically center better
         width: '50px',
         borderRadius: '100%',
         height: '50px',

--- a/src/components/AddTaskButton.js
+++ b/src/components/AddTaskButton.js
@@ -1,23 +1,26 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui';
+import { Link } from 'react-router-dom';
 
 export default function FloatingActionButtons() {
   return (
-    <button
+    <Link
+      to="/createtask"
       sx={{
         display: 'flex',
         justifyContent: 'center',
-        alignItems: 'center',
-        position: 'absolute',
+        // alignItems: 'center', // for some reason having this makes the text move lower and not look vertically centered
         width: '50px',
         borderRadius: '100%',
         height: '50px',
         fontSize: '2rem',
         bg: 'primary',
         border: 'none',
+        textDecoration: 'none',
+        color: 'text',
       }}
     >
       +
-    </button>
+    </Link>
   );
 }

--- a/src/components/dashboard/__tests__/Dashboard.test.js
+++ b/src/components/dashboard/__tests__/Dashboard.test.js
@@ -1,11 +1,12 @@
-/** @jsx jsx */
-import { jsx } from 'theme-ui';
-import { render } from '../../../../tests/themeProviderTestsUtil';
+import { renderWithRouter } from '../../../../tests/routerTestsUtil';
 
 import Dashboard from '../Dashboard';
 
 describe('Dashboard tests', () => {
   it('renders without crashing', () => {
-    render(<Dashboard />);
+    renderWithRouter(Dashboard, {
+      route: '/dashboard',
+      path: '/dashboard',
+    });
   });
 });


### PR DESCRIPTION
# Description
Changed the add icon from a `button` to a `Link` to direct the user to the `/createtask` route that has the create task form.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
No added tests

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
