### PR TITLE
Delete duplicate route. Change createtask route to be private

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,6 @@ import PrivateRoute from './PrivateRoute';
 import Dashboard from './components/dashboard/Dashboard';
 import LandingPage from './components/LandingPage';
 import LoginForm from './components/forms/LoginForm';
-import ViewTask from './components/ViewTask';
 import CreateTask from './components/forms/CreateTask';
 import AboutUs from './AboutUs';
 import Header from './components/header/Header';
@@ -23,9 +22,7 @@ const App = () => {
         <PrivateRoute exact path="/dashboard" component={Dashboard} />
         <Route path="/signup" component={SignUpForm} />
         <Route path="/login" component={LoginForm} />
-        <Route path="/viewtask" component={ViewTask} />
-        <Route path="/createtask" component={CreateTask} />
-        <Route path="/aboutus" component={AboutUs} />
+        <PrivateRoute path="/createtask" component={CreateTask} />
       </Switch>
     </Fragment>
   );

--- a/src/components/dashboard/TaskList.js
+++ b/src/components/dashboard/TaskList.js
@@ -29,7 +29,7 @@ const TaskList = () => {
     const userId = window.localStorage.getItem('userId');
 
     getTasks(userId);
-  }, []);
+  }, [getTasks]);
 
   return (
     <div

--- a/src/hooks/useDetectOutsideClick.js
+++ b/src/hooks/useDetectOutsideClick.js
@@ -23,5 +23,5 @@ export const useDetectOutsideClick = (ref, funcToExecute) => {
       // Unbind the event listener on clean up
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [ref]);
+  }, [ref, funcToExecute]);
 };


### PR DESCRIPTION
# Description
Deleted a duplicate `/aboutus` Route. Changed `/createtask` to be a PrivateRoute. Also removed the `/viewtask` Route because pulling up the component via the url doesn't tell the view task component which task to show. So just removed the Route for simplicity. We can add it back in if we figure out how to make it a dynamic route and pass in the individual task data.

Also updated the `useEffect` dependency arrays in 2 files (TaskList.js and useDetectOutsideClick.js) to get rid of error messages in the console.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Existing tests pass

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
