### PR TITLE
Update styling so delete task component doesn't take up whole height …

### DIFF
--- a/src/components/dashboard/taskCard/Task.js
+++ b/src/components/dashboard/taskCard/Task.js
@@ -115,10 +115,14 @@ const Task = ({ task }) => {
       )}
 
       {isDeleteModalOpen && (
-        <Modal onClose={() => setIsDeleteModalOpen(!isDeleteModalOpen)}>
-          <div>
-            <DeleteTask key={task.id} task={task} />
-          </div>
+        <Modal
+          onClose={() => setIsDeleteModalOpen(!isDeleteModalOpen)}
+          showX={false}
+          overrideStyles={{
+            height: `auto`,
+          }}
+        >
+          <DeleteTask key={task.id} task={task} />
         </Modal>
       )}
     </Fragment>

--- a/src/components/forms/DeleteTask.js
+++ b/src/components/forms/DeleteTask.js
@@ -19,13 +19,13 @@ const DeleteTask = ({ task }) => {
     <form
       onSubmit={handleSubmit}
       sx={{
-        width: `300px`,
-        margin: `0 auto`,
+        width: `100%`,
         display: `grid`,
         gridGap: `2px`,
+        textAlign: `center`,
       }}
     >
-      <h1>Are you sure want to delete this task?</h1>
+      <h2>Are you sure want to delete this task?</h2>
       <Button type="submit">Yes</Button>
     </form>
   );


### PR DESCRIPTION
…of screen

# Description
Updated the styling for the delete task form thing so the modal doesn't take up the entire height. Also adjusted the width property 'cause the button had some weird overflow stuff going on. Also got rid of the X (you can still close the form by clicking outside of the modal).

Open to any changes or suggestions!

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Styling update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Existing tests pass

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
