### PR TITLE
Move click handler that opens the view task modal to the whole card i…

### DIFF
--- a/src/components/dashboard/taskCard/Card.js
+++ b/src/components/dashboard/taskCard/Card.js
@@ -4,9 +4,10 @@ import { Card as ThemeCard } from '@theme-ui/components';
 import { motion } from 'framer-motion';
 import PropTypes from 'prop-types';
 
-const Card = ({ children }) => {
+const Card = ({ toggleViewTask, children }) => {
   return (
     <motion.div
+      onClick={() => toggleViewTask()}
       drag="x"
       dragConstraints={{ left: -100, right: 0 }}
       sx={{
@@ -49,6 +50,7 @@ const Card = ({ children }) => {
 // PropTypes.node means it can be of any type
 // PropTypes.oneOfType here is saying it's either going to be a single thing of any one type OR an array of things of any type
 Card.propTypes = {
+  toggleViewTask: PropTypes.func,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,

--- a/src/components/dashboard/taskCard/Task.js
+++ b/src/components/dashboard/taskCard/Task.js
@@ -55,7 +55,7 @@ const Task = ({ task }) => {
           position: `relative`,
         }}
       >
-        <Card>
+        <Card toggleViewTask={toggleViewTask}>
           {/* checkmark to toggle whether or not the task is complete */}
           <TaskCheckmark
             toggleComplete={toggleComplete}
@@ -69,24 +69,13 @@ const Task = ({ task }) => {
             isComplete={isComplete}
             isNotInitial={isNotInitial}
           />
-          <button
-            type="details"
-            onClick={toggleViewTask}
+
+          {/* just for some UX to help the user know to swipe the card */}
+          <FiChevronRight
             sx={{
-              width: `100%`,
-              height: `100%`,
-              display: `flex`,
-              alignItems: `center`,
-              justifyContent: `center`,
-              border: `none`,
-              bg: `background`,
-              padding: `0`,
               fontSize: `1.5rem`,
-              cursor: `pointer`,
             }}
-          >
-            <FiChevronRight />
-          </button>
+          />
         </Card>
 
         {/* edit and delete icons "hiding" behind the card */}


### PR DESCRIPTION
…nstead of the chevron arrow

# Description
Moved the click handler that opens the view task modal to the whole task card instead of the chevron arrow. Left the arrow in for UX purposes to help the user know they can slide/swipe the card, but we can always take it out if we don't want/like it.

Fixes # (issue)

## Type of change

- [x] Feature update (non-breaking change)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Existing tests pass

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
