### PR TITLE
Stop event propagation for checkmark click

### DIFF
--- a/src/components/dashboard/taskCard/Task.js
+++ b/src/components/dashboard/taskCard/Task.js
@@ -23,7 +23,8 @@ const Task = ({ task }) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isViewTaskOpen, setIsViewTaskOpen] = useState(false);
 
-  const toggleComplete = () => {
+  const toggleComplete = (e) => {
+    e.stopPropagation();
     // convert userId from localStorage to an int (comes back as a string originally)
     const userId = parseInt(localStorage.getItem('userId'));
 


### PR DESCRIPTION
# Description
Added an `e.stopPropagation` to the `toggleComplete` function that the task checkmarks use.

Fixes # (issue)
Clicking the task checkmark doesn't trigger a "click" on the task card that opens the view task modal

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Existing tests pass

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
